### PR TITLE
checking typeof navigator to support SSR

### DIFF
--- a/src/vendorSticky.js
+++ b/src/vendorSticky.js
@@ -1,5 +1,9 @@
 export default () => {
-    if (navigator && /Safari/.test(navigator.userAgent) && /Apple Computer/.test(navigator.vendor)) {
+    if (
+        typeof navigator !== 'undefined'
+        && /Safari/.test(navigator.userAgent)
+        && /Apple Computer/.test(navigator.vendor)
+    ) {
         return '-webkit-sticky';
     }
 


### PR DESCRIPTION
Thanks @marchaos for open-sourcing this 🙏 
I'm using it with a react project, and kept getting this exception on the server side rendering:

```
(node:39776) UnhandledPromiseRejectionWarning: ReferenceError: navigator is not defined
    at exports.default ([...]/node_modules/react-virtualized-sticky-tree/dist/commonjs/vendorSticky.js:8:5)
```

I edited the code to check the typeof navigator if it's not undefined - and it seems to solve that error.
Let me know if you can merge this to the master or if you have any question.