### PR TITLE
Fix broken Basic Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ const tree = {
 };
 
 const getChildren = (id) => {
-  return tree[id].children.map(id => ({ id, height: 30 }));
+  if (tree[id].children) {
+    return tree[id].children.map(id => ({ id, height: 30, isSticky: true }));
+  }
 };
 
 const rowRenderer = ({ id, style }) => {


### PR DESCRIPTION
Basic example would return `Cannot read property 'map' of undefined` as not all objects in the tree have children

Per issue #8