### PR TITLE
Prevent undefined error in backwardSearch

### DIFF
--- a/src/StickyTree.jsx
+++ b/src/StickyTree.jsx
@@ -723,6 +723,9 @@ export default class StickyTree extends React.PureComponent {
      */
     backwardSearch(scrollTop, searchPos) {
         const nodes = this.nodes;
+        if (searchPos > this.nodes.length) {
+            return 0;
+        }
         for (let i = searchPos; i >= 0; i--) {
             if (nodes[i].top <= scrollTop) {
                 return i;


### PR DESCRIPTION
#20 

Added a check to prevent an undefined error if the searchPos is larger then the node length.

If the searchPos is larger, I have returned 0 forcing it back to the top, are you happy with that logic?
