### PR TITLE
Issue 22

### DIFF
--- a/src/StickyTree.jsx
+++ b/src/StickyTree.jsx
@@ -742,11 +742,6 @@ export default class StickyTree extends React.PureComponent {
             return;
         }
 
-        // If we are scrolled to the bottom, no need to do any more work.
-        if (this.elem.scrollTop >= (this.elem.scrollHeight - this.elem.offsetHeight)) {
-            return;
-        }
-
         if (scrollTop >= (this.elem.scrollHeight - this.elem.offsetHeight)) {
             scrollTop = this.elem.scrollHeight - this.elem.offsetHeight;
         }

--- a/src/StickyTree.jsx
+++ b/src/StickyTree.jsx
@@ -723,6 +723,9 @@ export default class StickyTree extends React.PureComponent {
      */
     backwardSearch(scrollTop, searchPos) {
         const nodes = this.nodes;
+        if (searchPos > this.nodes.length) {
+            return 0;
+        }
         for (let i = searchPos; i >= 0; i--) {
             if (nodes[i].top <= scrollTop) {
                 return i;

--- a/src/StickyTree.jsx
+++ b/src/StickyTree.jsx
@@ -723,9 +723,6 @@ export default class StickyTree extends React.PureComponent {
      */
     backwardSearch(scrollTop, searchPos) {
         const nodes = this.nodes;
-        if (searchPos > this.nodes.length) {
-            return 0;
-        }
         for (let i = searchPos; i >= 0; i--) {
             if (nodes[i].top <= scrollTop) {
                 return i;


### PR DESCRIPTION
#22 

Removing this line as the previous update 2.1.26 caused an issue when scrolling quickly to the bottom of a tree and prevented the last render.