### PR TITLE
Cannot read property 'top' of undefined error

### DIFF
--- a/src/StickyTree.jsx
+++ b/src/StickyTree.jsx
@@ -724,7 +724,7 @@ export default class StickyTree extends React.PureComponent {
     backwardSearch(scrollTop, searchPos) {
         const nodes = this.nodes;
         for (let i = searchPos; i >= 0; i--) {
-            if (nodes[i].top <= scrollTop) {
+            if (nodes[i] && nodes[i].top <= scrollTop) {
                 return i;
             }
         }


### PR DESCRIPTION
Fix for the `Cannot read property 'top' of undefined ` error in backwardSearch ??