### PR TITLE
Fixed issue related to backward and forward both sections getting exe…

### DIFF
--- a/src/StickyTree.jsx
+++ b/src/StickyTree.jsx
@@ -747,12 +747,12 @@ export default class StickyTree extends React.PureComponent {
         if (scrollTop > this.state.scrollTop || currNodePos === 0) {
             pos = this.forwardSearch(scrollTop, currNodePos);
         }
-        if (scrollTop < this.state.scrollTop || pos === undefined) {
+        if (scrollTop < this.state.scrollTop && pos === undefined) {
             pos = this.backwardSearch(scrollTop, currNodePos);
         }
 
         this.pendingScrollTop = scrollTop;
-        this.setState({ currNodePos: pos, scrollTop, scrollReason }, () => {
+        this.setState({ currNodePos: pos ? pos : 0, scrollTop, scrollReason }, () => {
             this.pendingScrollTop = undefined;
         });
     }


### PR DESCRIPTION
…cuted and eventually cause pos to 0. Repro steps

1. Render tree with morethan 30K nodes.
2. Tree component is down deep in other components.
3. don't enable grouping. as it works fine with grouping.
4. delete one item from the list.
5. Make sure to choose another item in scrollIndex.
6. Repeat this couple of time and at some point setScrollTopAndClosestNode will trigger both forward and backward search section.

Forward search will correctly set the pos but then backward search will reset it back to 0 which will force the sticky tree to start rendering all 30K plus notes and the entire app hangs.

This small check will ensure that if pos is calculated it won't go inside backward search block.