### PR TITLE
Scroll top if equals to state.scrollTop should stop processing

### DIFF
--- a/src/StickyTree.jsx
+++ b/src/StickyTree.jsx
@@ -743,6 +743,10 @@ export default class StickyTree extends React.PureComponent {
             scrollTop = this.elem.scrollHeight - this.elem.offsetHeight;
         }
 
+        if (scrollTop === this.state.scrollTop) {
+            return;
+        }
+
         let pos;
         if (scrollTop > this.state.scrollTop || currNodePos === 0) {
             pos = this.forwardSearch(scrollTop, currNodePos);


### PR DESCRIPTION
For a huge tree with more than 10K nodes (sometimes 30K+) scrolltop was not equals to state.scrollTop but after new calculation (scrollTop = this.elem.scrollHeight - this.elem.offsetHeight;) it becomes equals to state.scrollTop hence pos is not calcualted again.

This works fine for the small tree but with more nodes, it triggers the re-rendering of entire app get hanged. 

A simple fix is to check and return if the scrollTop still equals to state.scrollTop