### PR TITLE
Prop for not setting inline width height

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-virtualized-sticky-tree",
   "description": "A React component for efficiently rendering tree like structures with support for position: sticky",
-  "version": "3.0.0-beta12",
+  "version": "3.0.0-beta13",
   "author": "Marc McIntyre <marchaos@gmail.com>",
   "license": "MIT",
   "main": "lib/src/index.js",

--- a/src/StickyTree.tsx
+++ b/src/StickyTree.tsx
@@ -145,6 +145,11 @@ export interface StickyTreeProps<TNodeType extends TreeNode = TreeNode, TMeta = 
     width: number;
 
     /**
+     * if false, then the width and height are not set as inline styles on the sticky tree element.
+     */
+    inlineWidthHeight?: boolean;
+
+    /**
      * if true, the root node will be rendered (by calling rowRenderer() for the root id). Otherwise no root node will be rendered.
      */
     renderRoot?: boolean;
@@ -930,11 +935,13 @@ export default class StickyTree<TNodeType extends TreeNode = TreeNode, TMeta = a
 
     render() {
         let style: React.CSSProperties = { overflow: 'auto', position: 'relative' };
-        if (this.props.width) {
-            style.width = this.props.width;
-        }
-        if (this.props.height) {
-            style.height = this.props.height;
+        if (this.props.inlineWidthHeight !== false) {
+            if (this.props.width) {
+                style.width = this.props.width;
+            }
+            if (this.props.height) {
+                style.height = this.props.height;
+            }
         }
 
         return (


### PR DESCRIPTION
Add a prop to allow NOT setting inline width and height on the sticky tree element.

This allows API users to override the width and height with CSS.